### PR TITLE
Refactor Systray to wrap interface instead of concrete type

### DIFF
--- a/tray.go
+++ b/tray.go
@@ -6,6 +6,25 @@ type Systray struct {
 	*_Systray
 }
 
+// systrayer interface represents the public
+// and private interface needed for a platform
+// specific systray implementation
+type systrayer interface {
+	Show(file, hint string) error
+	Stop() error
+	SetIcon(file string) error
+	SetTooltip(tooltip string) error
+	SetVisible(visible bool) error
+	Run() error
+	OnClick(fun func())
+	ClearSystrayMenuItems()
+	AddSystrayMenuItems(items []CallbackInfo)
+
+	// destroy gives implementation a chance to
+	// clean up resources
+	destroy()
+}
+
 func New(iconPath string, clientPath string) *Systray {
 	st := &Systray{_NewSystray(iconPath, clientPath)}
 

--- a/tray.go
+++ b/tray.go
@@ -3,7 +3,8 @@ package systray
 import "runtime"
 
 type Systray struct {
-	*_Systray
+	// platform-specific implementation
+	systrayer
 }
 
 // systrayer interface represents the public
@@ -26,14 +27,14 @@ type systrayer interface {
 }
 
 func New(iconPath string, clientPath string) *Systray {
+	// Wrap the platform-specific implementation in a
+	// public concrete type
 	st := &Systray{_NewSystray(iconPath, clientPath)}
 
 	// Track the cleanup of the public Systray instance,
 	// so that we can decref the wrapped private instance
 	runtime.SetFinalizer(st, func(ptr *Systray) {
-		if ptr._Systray != nil {
-			gSystrays.Decref(ptr._Systray.refId)
-		}
+		ptr.destroy()
 	})
 
 	return st

--- a/tray_darwin.go
+++ b/tray_darwin.go
@@ -66,6 +66,12 @@ func _NewSystrayEx(iconPath string) (*_Systray, error) {
 	return ni, nil
 }
 
+func (p *_Systray) destroy() {
+	if p != nil {
+		gSystrays.Decref(p.refId)
+	}
+}
+
 func (p *_Systray) Stop() error {
 	C.stopApplication()
 	return nil

--- a/tray_linux.go
+++ b/tray_linux.go
@@ -10,6 +10,8 @@ type _Systray struct {
 	dclick func()
 }
 
+func (p *_Systray) destroy() {}
+
 func (p *_Systray) Show(file string, hint string) error {
 	return nil
 }

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -7,6 +7,20 @@ import (
 	"unsafe"
 )
 
+type _Systray struct {
+	iconPath          string
+	id                uint32
+	mhwnd             uintptr
+	hwnd              uintptr
+	popupMenu         uintptr
+	menuItemCallbacks []CallbackInfo
+	lclick            func()
+	rclick            func()
+	dclick            func()
+}
+
+func (p *_Systray) destroy() {}
+
 func (p *_Systray) Stop() error {
 	nid := NOTIFYICONDATA{
 		UID:  p.id,
@@ -245,18 +259,6 @@ func _NewSystrayEx(iconPath string) (*_Systray, error) {
 	ni.hwnd = hwnd
 
 	return ni, nil
-}
-
-type _Systray struct {
-	iconPath          string
-	id                uint32
-	mhwnd             uintptr
-	hwnd              uintptr
-	popupMenu         uintptr
-	menuItemCallbacks []CallbackInfo
-	lclick            func()
-	rclick            func()
-	dclick            func()
 }
 
 func NewIconFromFile(filePath string) (uintptr, error) {


### PR DESCRIPTION
refs #2 

The merge from #2 left windows builds unable to succeed because of a missing `refId` field on its own `_Systray` struct. This merge refactors the public `Systray` struct to embed a `systrayer` interface instead of a concrete `_Systray`. The interface specifies what the platform needs to implement in terms of methods, so that platforms are free to have different fields on their structs as long as they have the correct methods.

Currently only the osx implementation uses the reference counting mechanism, so the `refId` field only needs to exist on that particular struct.

I've tested this as far as cross-compiling:

```bash
$ GOOS=darwin GOARCH=amd64 go build
$ GOOS=windows GOARCH=amd64 go build
$ GOOS=linux GOARCH=amd64 go build
```

The issue with the missing `refId` field under windows has been resolved by this refactor.